### PR TITLE
Add option DataMatrix

### DIFF
--- a/Com.SharpZebra/Com.SharpZebra.csproj
+++ b/Com.SharpZebra/Com.SharpZebra.csproj
@@ -12,6 +12,9 @@
     <Description>A .net library that simplifies printing to Zebra printers in their native EPL2/ZPL languages without needing to know EPL2 or ZPL.</Description>
     <PackageTags>Barcode Zebra Label</PackageTags>
     <Copyright>Copyright 2017</Copyright>
+  </PropertyGroup>  
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <DocumentationFile>bin\Release\net452\Com.SharpZebra.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
     <Compile Remove="Properties\AssemblyInfo.cs" />

--- a/Com.SharpZebra/Commands/StandardZPLCommand.cs
+++ b/Com.SharpZebra/Commands/StandardZPLCommand.cs
@@ -14,9 +14,9 @@ namespace Com.SharpZebra.Commands
             //^XA^MMT^PR4,12,12~TA000^LS-20^LH0,12~SD19^PW750
             _stringCounter = 0;
             _printerSettings = settings;
-            return Encoding.GetEncoding(850).GetBytes(string.Format("^XA^MMT^PR{0},12,12~TA{1:000}^LH{2},{3}~SD{4:00}^PW{5}", settings.PrintSpeed, 
-                settings.AlignTearOff, settings.AlignLeft, settings.AlignTop, settings.Darkness, settings.Width+settings.AlignLeft));
-        }        
+            return Encoding.GetEncoding(850).GetBytes(string.Format("^XA^MMT^PR{0},12,12~TA{1:000}^LH{2},{3}~SD{4:00}^PW{5}", settings.PrintSpeed,
+                settings.AlignTearOff, settings.AlignLeft, settings.AlignTop, settings.Darkness, settings.Width + settings.AlignLeft));
+        }
 
         public static byte[] PrintBuffer(int copies)
         {
@@ -27,9 +27,9 @@ namespace Com.SharpZebra.Commands
         {
             var encodedReadable = readable ? "Y" : "N";
             switch (barcode.Type)
-	        {
+            {
                 case BarcodeType.CODE39_STD_EXT:
-                    return Encoding.GetEncoding(850).GetBytes(string.Format("^FO{0},{1}^BY{2}^B3{3},,{4},{5}^FD{6}^FS", left, top, 
+                    return Encoding.GetEncoding(850).GetBytes(string.Format("^FO{0},{1}^BY{2}^B3{3},,{4},{5}^FD{6}^FS", left, top,
                         barcode.BarWidthNarrow, (char)rotation, height, encodedReadable, barcodeData));
                 case BarcodeType.CODE128_AUTO:
                     return Encoding.GetEncoding(850).GetBytes(string.Format("^FO{0},{1}^BY{2}^BC{3},{4},{5}^FD{6}^FS", left, top,
@@ -40,9 +40,31 @@ namespace Com.SharpZebra.Commands
                 case BarcodeType.EAN13:
                     return Encoding.GetEncoding(850).GetBytes(string.Format("^FO{0},{1}^BY{2}^BE{3},{4},{5}^FD{6}^FS", left, top,
                         barcode.BarWidthNarrow, (char)rotation, height, encodedReadable, barcodeData));
-		        default:
-                    throw new ApplicationException("Barcode not yet supported by SharpZebra library.");                
-	        }
+                default:
+                    throw new ApplicationException("Barcode not yet supported by SharpZebra library.");
+            }
+        }
+
+        /// <summary>
+        /// Writes Data Matrix Bar Code for ZPL. 
+        /// ZPL Command: ^BX.
+        /// Manual: <see href="https://www.zebra.com/content/dam/zebra/manuals/printers/common/programming/zpl-zbi2-pm-en.pdf#page=122"/>     
+        /// </summary>
+        /// <param name="left">Horizontal axis.</param>
+        /// <param name="top">Vertical axis.</param>
+        /// <param name="height">Height is determined by dimension and data that is encoded.</param>
+        /// <param name="rotation">Rotate field.</param>
+        /// <param name="text">Text to be encoded</param>                            
+        /// <param name="qualityLevel">Version of Data Matrix.</param>
+        /// <param name="aspectRatio">Choices the symbol, it is possible encode the same data in two forms of Data Matrix, a square form or rectangular.</param>
+        /// <returns>Array of bytes containing ZPLII data to be sent to the Zebra printer.</returns>
+        public static byte[] DataMatrixWrite(int left, int top, ElementDrawRotation rotation, int height, string text, QualityLevel qualityLevel = QualityLevel.ECC_200, AspectRatio aspectRatio = AspectRatio.SQUARE)
+        {
+            var rotationValue = (char)rotation;
+            var qualityLevelValue = (int)qualityLevel;
+            var aspectRatioValue = (int)aspectRatio;
+
+            return Encoding.GetEncoding(850).GetBytes($"^FO{left},{top}^BX{rotationValue}, {height},{qualityLevelValue},,,,,{aspectRatioValue},^FD{text}^FS");
         }
 
         public static byte[] TextWrite(int left, int top, ElementDrawRotation rotation, ZebraFont font, int height, int width, string text, int codepage = 850)
@@ -52,7 +74,7 @@ namespace Com.SharpZebra.Commands
 
         public static byte[] TextWrite(int left, int top, ElementDrawRotation rotation, string fontName, char storageArea, int height, string text, int codepage = 850)
         {
-            return Encoding.GetEncoding(codepage).GetBytes(string.Format("^A@{0},{1},{1},{2}:{3}^FO{4},{5}^FD{6}^FS",(char)rotation, height, storageArea, fontName, left, top, text));
+            return Encoding.GetEncoding(codepage).GetBytes(string.Format("^A@{0},{1},{1},{2}:{3}^FO{4},{5}^FD{6}^FS", (char)rotation, height, storageArea, fontName, left, top, text));
         }
 
         public static byte[] TextWrite(int left, int top, ElementDrawRotation rotation, int height, string text, int codepage = 850)
@@ -66,7 +88,7 @@ namespace Com.SharpZebra.Commands
             return TextAlign(width, alignment, 1, 0, 0, textCommand);
         }
 
-        public static byte[] TextAlign (int width, Alignment alignment, int maxLines, int lineSpacing, int indentSize, byte[] textCommand, int codepage = 850)
+        public static byte[] TextAlign(int width, Alignment alignment, int maxLines, int lineSpacing, int indentSize, byte[] textCommand, int codepage = 850)
         {
             //limits from ZPL Manual:
             //width [0,9999]
@@ -76,7 +98,7 @@ namespace Com.SharpZebra.Commands
 
             var stream = new MemoryStream();
             var writer = new BinaryWriter(stream);
-            writer.Write(textCommand.Take(textCommand.Length-3).ToArray()); //strip ^FS from given command
+            writer.Write(textCommand.Take(textCommand.Length - 3).ToArray()); //strip ^FS from given command
             var s = string.Format("^FB{0},{1},{2},{3},{4}^FS", width, maxLines, lineSpacing, (char)alignment, indentSize);
             writer.Write(Encoding.GetEncoding(codepage).GetBytes(s));
             return stream.ToArray();
@@ -84,8 +106,8 @@ namespace Com.SharpZebra.Commands
 
         public static byte[] LineWrite(int left, int top, int lineThickness, int right, int bottom)
         {
-            var height = top-bottom;
-            var width = right - left;            
+            var height = top - bottom;
+            var width = right - left;
             var diagonal = height * width < 0 ? 'L' : 'R';
             var l = Math.Min(left, right);
             var t = Math.Min(top, bottom);
@@ -94,17 +116,17 @@ namespace Com.SharpZebra.Commands
 
             //zpl requires that straight lines are drawn with GB (Graphic-Box)
             if (width < lineThickness)
-                return BoxWrite(left-((int)(lineThickness/2)), top, lineThickness, width, height, 0);
+                return BoxWrite(left - ((int)(lineThickness / 2)), top, lineThickness, width, height, 0);
             if (height < lineThickness)
-                return BoxWrite(left, top-((int)(lineThickness/2)), lineThickness, width, height, 0);
-            
-            return Encoding.GetEncoding(850).GetBytes(string.Format("^FO{0},{1}^GD{2},{3},{4},{5},{6}^FS", l, t, width, height, 
+                return BoxWrite(left, top - ((int)(lineThickness / 2)), lineThickness, width, height, 0);
+
+            return Encoding.GetEncoding(850).GetBytes(string.Format("^FO{0},{1}^GD{2},{3},{4},{5},{6}^FS", l, t, width, height,
                     lineThickness, "", diagonal));
         }
 
         public static byte[] BoxWrite(int left, int top, int lineThickness, int width, int height, int rounding)
         {
-            return Encoding.GetEncoding(850).GetBytes(string.Format("^FO{0},{1}^GB{2},{3},{4},{5},{6}^FS", left, top, 
+            return Encoding.GetEncoding(850).GetBytes(string.Format("^FO{0},{1}^GB{2},{3},{4},{5},{6}^FS", left, top,
                 Math.Max(width, lineThickness), Math.Max(height, lineThickness), lineThickness, "", rounding));
         }
         /*

--- a/Com.SharpZebra/EnumDefinitions.cs
+++ b/Com.SharpZebra/EnumDefinitions.cs
@@ -166,6 +166,20 @@ namespace Com.SharpZebra
         UK = 44
     }
 
+    public enum QualityLevel
+    {
+        ECC_50 = 50,
+        ECC_80 = 80,
+        ECC_100 = 100,
+        ECC_140 = 140,
+        ECC_200 = 200,
+    }
+
+    public enum AspectRatio
+    {
+        SQUARE = 1,
+        RECTANGULAR = 2
+    }
 
     public static class FontCharset
     {
@@ -175,7 +189,7 @@ namespace Com.SharpZebra
             "ABCDEFGHIJKLMNOPQRSTUVWXYZ ",
             "abcdefghijklmnopqrstuvwxyz 0123456789.-",
             "ABCDEFGHIJKLMNOPQRSTUVWXYZ 0123456789.-",
-            " !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~" + 
+            " !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~" +
             "ÇüéâäàåçêëèïîìÄÅÉæÆôöòûùÿÖÜ¢£¥₧ƒáíóúñÑªº¿⌐¬½¼¡«»αßΓπΣσµτΦΘΩδ∞φε∩≡±≥≤⌠⌡÷≈°∙·√ⁿ² ",
             "M"};
     }
@@ -203,12 +217,12 @@ namespace Com.SharpZebra
     public class Barcode
     {
         private BarcodeType type;
-        public BarcodeType Type 
+        public BarcodeType Type
         {
-            get {return type;}
+            get { return type; }
             set
             {
-                type = value; 
+                type = value;
                 P4Value = P4ValueList[(int)type];
                 BarWidthNarrowMin = P5MinList[(int)type];
                 BarWidthNarrowMax = P5MaxList[(int)type];


### PR DESCRIPTION
If it to interests you, [I implemented](https://github.com/rkone/sharpzebra/compare/master...Rondinelly:data_matrix_write#diff-22e712573ba75d493da016890ffa60ecR61) the DataMatrix barcode writing for ZPL according to the [Manual](https://www.zebra.com/content/dam/zebra/manuals/printers/common/programming/zpl-zbi2-pm-en.pdf#page=122)

**Follow example:**

```cs
var page = new List<byte>();
page.AddRange(ZPLCommands.ClearPrinter(printerSetting));
page.AddRange(ZPLCommands.DataMatrixWrite(10, 10, ElementDrawRotation.NO_ROTATION, 10, "Test"));          
            
 Print(page, printerSetting);
```

**Result:**

http://labelary.com/viewer.html?density=8&width=4&height=6&units=inches&index=0&zpl=%5EXA%5EMMT%5EPR0%2C12%2C12~TA000%5ELH0%2C0~SD30%5EPW812%5EFO10%2C10%5EBXN%2C%2010%2C200%2C%2C%2C%2C%2C1%2C%5EFDTest%5EFS%5EXZ

There were also some indentations due to the Visual Studio.

If need some adjustment, I'm ready to do it.