### PR TITLE
Fix missing Port exception & improve "Cannot locate" message

### DIFF
--- a/Com.SharpZebra/Printing/USBPrinter.cs
+++ b/Com.SharpZebra/Printing/USBPrinter.cs
@@ -80,8 +80,8 @@ namespace SharpZebra.Printing
             {
                 subKey = Registry.LocalMachine.OpenSubKey("SYSTEM\\CurrentControlSet\\Control\\Print\\Printers\\" + printer);
                 if (subKey == null) continue;
-                var portValue = subKey.GetValue("Port").ToString();
-                if (portValue.Substring(0, 3) == "USB")
+                var portValue = subKey.GetValue("Port", string.Empty).ToString();
+                if (portValue.Length >= 3 && portValue.Substring(0, 3) == "USB")
                 {
                     if (int.TryParse(portValue.Substring(3, portValue.Length - 3), out portNumber))
                     {
@@ -139,7 +139,7 @@ namespace SharpZebra.Printing
             if (plist.ContainsKey(printerName))
                 _interfaceName = plist[printerName];
             else
-                throw new Exception("Cannot locate USB device");
+                throw new Exception($"No printer named {printerName} was found connected via USB.");
         }
 
         /// <summary>


### PR DESCRIPTION
I have changed 2 things with this PR:

1. I was getting an exception and narrowed it down to a printer entry in my registry missing the Port key. I have added handling for missing keys to avoid this exception.
2. I have improved the exception that is thrown when the USB printer is not found.